### PR TITLE
Replace PDB molecule image with Aspen Protein Viewer component

### DIFF
--- a/bio-pdb-list.js
+++ b/bio-pdb-list.js
@@ -33,6 +33,7 @@ class BioPdbList extends PolymerElement {
         paper-item {
           background-color: transparent;
           color: white;
+          cursor: pointer;
           font-size: 0.9em;
 
           --paper-item-selected: {

--- a/bio-pdb-viewer.js
+++ b/bio-pdb-viewer.js
@@ -1,7 +1,9 @@
 import { PolymerElement, html } from "@polymer/polymer/polymer-element";
 
+import "aspen-protein-viewer/ngl-viewer";
+
 /**
- * `bio-pdb-viewer` This component displays a PDB molecule image.
+ * `bio-pdb-viewer` This component displays a PDB molecule 3D view.
  *
  * @summary ShortDescription.
  * @customElement
@@ -17,12 +19,15 @@ class BioPdbViewer extends PolymerElement {
           --height: 100%;
           --width: 100%;
         }
-        img {
+        .threeD-protein {
           height: var(--height);
           width: var(--width);
         }
       </style>
-      <img id="pdbImg" title="{{title}}" />
+
+      <div class="threeD-protein" title="[[pdbId]]">
+        <ngl-viewer data-resource="rcsb://[[pdbId]]"></ngl-viewer>
+      </div>
     `;
   }
 
@@ -42,8 +47,7 @@ class BioPdbViewer extends PolymerElement {
       pdbId: {
         type: String,
         value: "4LUC",
-        observer: "pdbIdChanged",
-        notify: true
+        notify: true,
       },
 
       /** The type of molecule. */
@@ -51,38 +55,7 @@ class BioPdbViewer extends PolymerElement {
 
       /** The size of the molecule image. */
       size: { type: String, value: "250" },
-
-      /** The title of the image. */
-      title: { type: String, value: "KRAS" }
     };
-  }
-
-  /**
-   * Instance of the element is created/upgraded. Use: initializing state,
-   * set up event listeners, create shadow dom.
-   * @constructor
-   */
-  constructor() {
-    super();
-  }
-
-  /**
-   * Use for one-time configuration of your component after local DOM is initialized.
-   */
-  ready() {
-    super.ready();
-    this.$.pdbImg.src = this._getUrl();
-  }
-
-  pdbIdChanged(newVal) {
-    this.$.pdbImg.src = this._getUrl();
-    this.title = this.pdbId;
-  }
-
-  _getUrl() {
-    let id = this.pdbId.toLowerCase();
-    let folder = id.substring(1, 3);
-    return `https://cdn.rcsb.org/images/rutgers/${folder}/${id}/${id}.pdb1-250.jpg`;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@biopolymer-elements/bio-pdb",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17,10 +17,31 @@
       "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.3.tgz",
       "integrity": "sha512-fRuET+UGrH84hG0UF4iHbFqWZKUoan4/ki+iCOJ/vnKltPSHv/ZVbcA6sT/pRreznt8aKEGqN2KdHvgRxn4xjA=="
     },
+    "aspen-protein-viewer": {
+      "version": "github:aspen-elements/aspen-protein-viewer#55ac33b9869c87f3daf4d40741c3fef2bb1d29b8",
+      "from": "github:aspen-elements/aspen-protein-viewer#v1.0.0",
+      "requires": {
+        "lit-element": "^2.4.0",
+        "lit-html": "^1.3.0"
+      }
+    },
     "i": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
       "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0="
+    },
+    "lit-element": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.4.0.tgz",
+      "integrity": "sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==",
+      "requires": {
+        "lit-html": "^1.1.1"
+      }
+    },
+    "lit-html": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.3.0.tgz",
+      "integrity": "sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q=="
     },
     "npm": {
       "version": "6.13.4",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "bio-pdb-card.js",
   "dependencies": {
     "@polymer/polymer": "^3.3.1",
+    "aspen-protein-viewer": "github:aspen-elements/aspen-protein-viewer#v1.0.0",
     "i": "^0.3.6",
     "npm": "^6.13.4"
   },


### PR DESCRIPTION
## Description
The image url is broken. In order to overcome the broken image link problem, the image needs to be replaced with Aspen Protein Viewer Component which provides 3D view of the protein structure for a given `pdb-id`.

## Summary of Changes
- [X] Replace image with `nlg-viewer` component
- [X] Remove unused code (constructor, ready, pubIdChanged and getUrl methods)
- [X] Add cursor pointer to list items